### PR TITLE
refactor: simplify `MultipartBodyPublisher` for memory efficiency

### DIFF
--- a/src/main/java/com/uvasoftware/scanii/internal/MultipartBodyPublisher.java
+++ b/src/main/java/com/uvasoftware/scanii/internal/MultipartBodyPublisher.java
@@ -1,21 +1,28 @@
 package com.uvasoftware.scanii.internal;
 
-import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.UncheckedIOException;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 class MultipartBodyPublisher {
   private final String boundary;
-  private final ByteArrayOutputStream out;
+  private final List<Supplier<InputStream>> parts;
 
   MultipartBodyPublisher() {
     this.boundary = UUID.randomUUID().toString();
-    this.out = new ByteArrayOutputStream();
+    this.parts = new ArrayList<>();
   }
 
   String contentType() {
@@ -23,49 +30,60 @@ class MultipartBodyPublisher {
   }
 
   MultipartBodyPublisher addTextBody(String name, String value) {
-    writeString("--" + boundary + "\r\n");
-    writeString("Content-Disposition: form-data; name=\"" + name + "\"\r\n");
-    writeString("Content-Type: text/plain; charset=UTF-8\r\n\r\n");
-    writeString(value + "\r\n");
+    byte[] bytes = ("--" + boundary + "\r\n"
+      + "Content-Disposition: form-data; name=\"" + name + "\"\r\n"
+      + "Content-Type: text/plain; charset=UTF-8\r\n\r\n"
+      + value + "\r\n").getBytes(StandardCharsets.UTF_8);
+    parts.add(() -> new ByteArrayInputStream(bytes));
     return this;
   }
 
   MultipartBodyPublisher addBinaryBody(String name, Path file) {
-    try {
-      writeString("--" + boundary + "\r\n");
-      writeString("Content-Disposition: form-data; name=\"" + name + "\"; filename=\"" + file.getFileName() + "\"\r\n");
-      writeString("Content-Type: application/octet-stream\r\n\r\n");
-      out.write(Files.readAllBytes(file));
-      writeString("\r\n");
-      return this;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    byte[] header = ("--" + boundary + "\r\n"
+      + "Content-Disposition: form-data; name=\"" + name + "\"; filename=\"" + file.getFileName() + "\"\r\n"
+      + "Content-Type: application/octet-stream\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+    byte[] trailer = "\r\n".getBytes(StandardCharsets.UTF_8);
+    parts.add(() -> new ByteArrayInputStream(header));
+    parts.add(() -> {
+      try {
+        return Files.newInputStream(file);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    parts.add(() -> new ByteArrayInputStream(trailer));
+    return this;
   }
 
   MultipartBodyPublisher addBinaryBody(String name, InputStream stream) {
-    try {
-      writeString("--" + boundary + "\r\n");
-      writeString("Content-Disposition: form-data; name=\"" + name + "\"; filename=\"upload\"\r\n");
-      writeString("Content-Type: application/octet-stream\r\n\r\n");
-      out.write(stream.readAllBytes());
-      writeString("\r\n");
-      return this;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    byte[] header = ("--" + boundary + "\r\n"
+      + "Content-Disposition: form-data; name=\"" + name + "\"; filename=\"upload\"\r\n"
+      + "Content-Type: application/octet-stream\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+    byte[] trailer = "\r\n".getBytes(StandardCharsets.UTF_8);
+    parts.add(() -> new ByteArrayInputStream(header));
+    parts.add(() -> stream);
+    parts.add(() -> new ByteArrayInputStream(trailer));
+    return this;
   }
 
   HttpRequest.BodyPublisher build() {
-    writeString("--" + boundary + "--\r\n");
-    return HttpRequest.BodyPublishers.ofByteArray(out.toByteArray());
-  }
+    byte[] closing = ("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+    parts.add(() -> new ByteArrayInputStream(closing));
 
-  private void writeString(String s) {
-    try {
-      out.write(s.getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    Iterator<Supplier<InputStream>> iterator = parts.iterator();
+    @SuppressWarnings("resource")
+    InputStream combined = new SequenceInputStream(new Enumeration<>() {
+      @Override
+      public boolean hasMoreElements() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public InputStream nextElement() {
+        return iterator.next().get();
+      }
+    });
+
+    return HttpRequest.BodyPublishers.ofInputStream(() -> combined);
   }
 }

--- a/src/test/java/com/uvasoftware/scanii/internal/MultipartBodyPublisherTest.java
+++ b/src/test/java/com/uvasoftware/scanii/internal/MultipartBodyPublisherTest.java
@@ -1,36 +1,44 @@
 package com.uvasoftware.scanii.internal;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+@Execution(ExecutionMode.CONCURRENT)
 class MultipartBodyPublisherTest {
 
   private static String bodyToString(HttpRequest.BodyPublisher publisher) {
-    byte[] bytes = new byte[(int) publisher.contentLength()];
-    publisher.subscribe(new java.util.concurrent.Flow.Subscriber<>() {
-      int offset = 0;
-      java.util.concurrent.Flow.Subscription sub;
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    CountDownLatch latch = new CountDownLatch(1);
+
+    publisher.subscribe(new Flow.Subscriber<>() {
+      Flow.Subscription sub;
 
       @Override
-      public void onSubscribe(java.util.concurrent.Flow.Subscription subscription) {
+      public void onSubscribe(Flow.Subscription subscription) {
         this.sub = subscription;
         subscription.request(Long.MAX_VALUE);
       }
 
       @Override
-      public void onNext(java.nio.ByteBuffer item) {
-        int len = item.remaining();
-        item.get(bytes, offset, len);
-        offset += len;
+      public void onNext(ByteBuffer item) {
+        byte[] bytes = new byte[item.remaining()];
+        item.get(bytes);
+        out.write(bytes, 0, bytes.length);
       }
 
       @Override
@@ -40,19 +48,26 @@ class MultipartBodyPublisherTest {
 
       @Override
       public void onComplete() {
+        latch.countDown();
       }
     });
-    return new String(bytes, StandardCharsets.UTF_8);
+
+    try {
+      Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS), "Timed out waiting for body publisher");
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    return out.toString(StandardCharsets.UTF_8);
   }
 
   @Test
   void contentTypeShouldContainBoundary() {
     MultipartBodyPublisher pub = new MultipartBodyPublisher();
     String ct = pub.contentType();
-    assertTrue(ct.startsWith("multipart/form-data; boundary="));
+    Assertions.assertTrue(ct.startsWith("multipart/form-data; boundary="));
     // boundary should be non-empty after the prefix
     String boundary = ct.substring("multipart/form-data; boundary=".length());
-    assertFalse(boundary.isEmpty());
+    Assertions.assertFalse(boundary.isEmpty());
   }
 
   @Test
@@ -63,11 +78,11 @@ class MultipartBodyPublisherTest {
 
     String boundary = pub.contentType().substring("multipart/form-data; boundary=".length());
 
-    assertTrue(body.contains("--" + boundary + "\r\n"));
-    assertTrue(body.contains("Content-Disposition: form-data; name=\"callback\""));
-    assertTrue(body.contains("Content-Type: text/plain; charset=UTF-8"));
-    assertTrue(body.contains("https://example.com/hook"));
-    assertTrue(body.endsWith("--" + boundary + "--\r\n"));
+    Assertions.assertTrue(body.contains("--" + boundary + "\r\n"));
+    Assertions.assertTrue(body.contains("Content-Disposition: form-data; name=\"callback\""));
+    Assertions.assertTrue(body.contains("Content-Type: text/plain; charset=UTF-8"));
+    Assertions.assertTrue(body.contains("https://example.com/hook"));
+    Assertions.assertTrue(body.endsWith("--" + boundary + "--\r\n"));
   }
 
   @Test
@@ -83,10 +98,10 @@ class MultipartBodyPublisherTest {
 
       String boundary = pub.contentType().substring("multipart/form-data; boundary=".length());
 
-      assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"" + tmp.getFileName() + "\""));
-      assertTrue(body.contains("Content-Type: application/octet-stream"));
-      assertTrue(body.contains("file-content-here"));
-      assertTrue(body.endsWith("--" + boundary + "--\r\n"));
+      Assertions.assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"" + tmp.getFileName() + "\""));
+      Assertions.assertTrue(body.contains("Content-Type: application/octet-stream"));
+      Assertions.assertTrue(body.contains("file-content-here"));
+      Assertions.assertTrue(body.endsWith("--" + boundary + "--\r\n"));
     } finally {
       Files.deleteIfExists(tmp);
     }
@@ -103,10 +118,10 @@ class MultipartBodyPublisherTest {
 
     String boundary = pub.contentType().substring("multipart/form-data; boundary=".length());
 
-    assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"upload\""));
-    assertTrue(body.contains("Content-Type: application/octet-stream"));
-    assertTrue(body.contains("stream-data"));
-    assertTrue(body.endsWith("--" + boundary + "--\r\n"));
+    Assertions.assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"upload\""));
+    Assertions.assertTrue(body.contains("Content-Type: application/octet-stream"));
+    Assertions.assertTrue(body.contains("stream-data"));
+    Assertions.assertTrue(body.endsWith("--" + boundary + "--\r\n"));
   }
 
   @Test
@@ -124,17 +139,17 @@ class MultipartBodyPublisherTest {
       String boundary = pub.contentType().substring("multipart/form-data; boundary=".length());
 
       // all three parts should be present
-      assertTrue(body.contains("name=\"file\""));
-      assertTrue(body.contains("binary-data"));
-      assertTrue(body.contains("name=\"metadata[tag]\""));
-      assertTrue(body.contains("important"));
-      assertTrue(body.contains("name=\"callback\""));
-      assertTrue(body.contains("https://example.com"));
+      Assertions.assertTrue(body.contains("name=\"file\""));
+      Assertions.assertTrue(body.contains("binary-data"));
+      Assertions.assertTrue(body.contains("name=\"metadata[tag]\""));
+      Assertions.assertTrue(body.contains("important"));
+      Assertions.assertTrue(body.contains("name=\"callback\""));
+      Assertions.assertTrue(body.contains("https://example.com"));
 
       // should have exactly 3 part boundaries + 1 closing boundary
       int partCount = countOccurrences(body, "--" + boundary + "\r\n");
-      assertEquals(3, partCount);
-      assertTrue(body.endsWith("--" + boundary + "--\r\n"));
+      Assertions.assertEquals(3, partCount);
+      Assertions.assertTrue(body.endsWith("--" + boundary + "--\r\n"));
     } finally {
       Files.deleteIfExists(tmp);
     }
@@ -146,14 +161,14 @@ class MultipartBodyPublisherTest {
     MultipartBodyPublisher result = pub
       .addTextBody("a", "1")
       .addTextBody("b", "2");
-    assertSame(pub, result);
+    Assertions.assertSame(pub, result);
   }
 
   @Test
   void shouldSupportFluentChainingForBinaryStream() {
     MultipartBodyPublisher pub = new MultipartBodyPublisher();
     MultipartBodyPublisher result = pub.addBinaryBody("file", new ByteArrayInputStream(new byte[0]));
-    assertSame(pub, result);
+    Assertions.assertSame(pub, result);
   }
 
   @Test
@@ -162,7 +177,7 @@ class MultipartBodyPublisherTest {
     try {
       MultipartBodyPublisher pub = new MultipartBodyPublisher();
       MultipartBodyPublisher result = pub.addBinaryBody("file", tmp);
-      assertSame(pub, result);
+      Assertions.assertSame(pub, result);
     } finally {
       Files.deleteIfExists(tmp);
     }
@@ -177,11 +192,11 @@ class MultipartBodyPublisherTest {
       pub.addBinaryBody("file", tmp);
       String body = bodyToString(pub.build());
 
-      assertTrue(body.contains("name=\"file\""));
+      Assertions.assertTrue(body.contains("name=\"file\""));
       // binary section should have the headers but no file content between them and the boundary
       String boundary = pub.contentType().substring("multipart/form-data; boundary=".length());
-      assertTrue(body.contains("Content-Type: application/octet-stream\r\n\r\n\r\n"));
-      assertTrue(body.endsWith("--" + boundary + "--\r\n"));
+      Assertions.assertTrue(body.contains("Content-Type: application/octet-stream\r\n\r\n\r\n"));
+      Assertions.assertTrue(body.endsWith("--" + boundary + "--\r\n"));
     } finally {
       Files.deleteIfExists(tmp);
     }
@@ -193,23 +208,24 @@ class MultipartBodyPublisherTest {
     pub.addBinaryBody("file", new ByteArrayInputStream(new byte[0]));
     String body = bodyToString(pub.build());
 
-    assertTrue(body.contains("name=\"file\""));
-    assertTrue(body.contains("Content-Type: application/octet-stream\r\n\r\n\r\n"));
+    Assertions.assertTrue(body.contains("name=\"file\""));
+    Assertions.assertTrue(body.contains("Content-Type: application/octet-stream\r\n\r\n\r\n"));
   }
 
   @Test
-  void contentLengthShouldBePositive() {
+  void shouldStreamWithoutKnownContentLength() {
     MultipartBodyPublisher pub = new MultipartBodyPublisher();
     pub.addTextBody("key", "value");
     HttpRequest.BodyPublisher bp = pub.build();
-    assertTrue(bp.contentLength() > 0);
+    // streaming publisher reports unknown content length
+    Assertions.assertEquals(-1, bp.contentLength());
   }
 
   @Test
   void eachInstanceShouldHaveUniqueBoundary() {
     MultipartBodyPublisher a = new MultipartBodyPublisher();
     MultipartBodyPublisher b = new MultipartBodyPublisher();
-    assertNotEquals(a.contentType(), b.contentType());
+    Assertions.assertNotEquals(a.contentType(), b.contentType());
   }
 
   private static int countOccurrences(String haystack, String needle) {


### PR DESCRIPTION
- Replaced `ByteArrayOutputStream` with a streaming-based model using `InputStream` and `Supplier`.
- Avoided loading entire multipart content into memory, improving scalability for large payloads.
- Updated tests to validate streaming approach and ensure boundary correctness.