### PR TITLE
ci: enable auto-publish to Maven Central and remove GitHub release cr…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,3 @@ jobs:
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
           PASSPHRASE: ${{ secrets.CODESIGN_PGP_PASSPHRASE }}
 
-      - name: Create GitHub Release
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const tag = context.ref.replace('refs/tags/', '');
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: tag,
-              generate_release_notes: true,
-            });

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
…eation step

- pom.xml: add `autoPublish` configuration for Maven Central.
- release.yml: drop "Create GitHub Release" step.