### PR TITLE
fix: bump README install snippet to 8.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official Java SDK for the [Scanii](https://www.scanii.com) content processing AP
 <dependency>
   <groupId>com.scanii</groupId>
   <artifactId>scanii-java</artifactId>
-  <version>8.1.0</version>
+  <version>8.2.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Missed in the deprecate-auto-endpoint PR — README install snippet still showed `8.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)