### PR TITLE
Bump CI actions and JUnit test dependency

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [21, 25]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
           distribution: corretto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Release to Maven Central
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Java for signing and publishing
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: corretto

--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.12.2</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.12.2</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Routine dependency maintenance for scanii-java. **No runtime dependencies** added or changed (stays stdlib-only).

## Changes

**GitHub Actions (latest major)**
- `actions/checkout` v4 → v7
- `actions/setup-java` v4 → v5 (in both `pr.yml` and `release.yml`)

**Test dependency (test scope only)**
- `junit-jupiter-engine` 5.12.2 → 5.14.4
- `junit-jupiter-params` 5.12.2 → 5.14.4

## Verification

`mvn -B verify` against local scanii-cli mock: **BUILD SUCCESS** — 100 tests, 0 failures, 1 skipped (self-skip). CI exercises the full JDK 21/25 × ubuntu/macos/windows matrix.

## Notes

- `scanii/setup-cli-action@v1` left as-is (floats within v1).
- `checkout@v7` persists git credentials to a separate file vs. v4; `release.yml` uses Maven/GPG secrets directly, not the checkout-persisted credential, so the publish path is unaffected.